### PR TITLE
fix(CommandHandler): deal with path resolution agnostically 

### DIFF
--- a/packages/bot/src/struct/CommandHandler.ts
+++ b/packages/bot/src/struct/CommandHandler.ts
@@ -183,7 +183,7 @@ export class CommandHandler {
 				continue;
 			}
 
-			const mod = (await import(file)) as { default: ComponentConstructor };
+			const mod = (await import(pathToFileURL(file).toString())) as { default: ComponentConstructor };
 			const component = container.resolve(mod.default);
 			const name = component.name ?? info.name;
 

--- a/packages/bot/src/struct/CommandHandler.ts
+++ b/packages/bot/src/struct/CommandHandler.ts
@@ -1,5 +1,5 @@
 import { dirname, join } from 'node:path';
-import { fileURLToPath } from 'node:url';
+import { fileURLToPath, pathToFileURL } from 'node:url';
 import { readdirRecurse } from '@chatsift/readdir';
 import { REST } from '@discordjs/rest';
 import { PrismaClient } from '@prisma/client';
@@ -166,7 +166,7 @@ export class CommandHandler {
 		const files = readdirRecurse(path, { fileExtensions: ['js'] });
 
 		for await (const file of files) {
-			const mod = (await import(file)) as { default: CommandConstructor };
+			const mod = (await import(pathToFileURL(file).toString())) as { default: CommandConstructor };
 			const command = container.resolve(mod.default);
 
 			this.commands.set(command.interactionOptions.name, command);


### PR DESCRIPTION
fixes a traceback error that arose when trying to deploy commands on a windows based machine.