### PR TITLE
fix: silent not being taken into account with time

### DIFF
--- a/packages/bot/src/commands/close.ts
+++ b/packages/bot/src/commands/close.ts
@@ -103,9 +103,11 @@ export default class implements Command<ApplicationCommandType.ChatInput> {
 					threadId: thread.threadId,
 					closeAt,
 					scheduledById: interaction.user.id,
+					silent,
 				},
 				update: {
 					closeAt,
+					silent,
 				},
 				where: { threadId: thread.threadId },
 			});


### PR DESCRIPTION
Fixes `/close` command not taking into account the silent option when the time option exists