### PR TITLE
refactor: isolate thread management logic

### DIFF
--- a/packages/bot/src/commands/context-menus/open.ts
+++ b/packages/bot/src/commands/context-menus/open.ts
@@ -1,5 +1,4 @@
-import type { PrismaClient } from '@prisma/client';
-import { ApplicationCommandType, type Client, type UserContextMenuCommandInteraction } from 'discord.js';
+import { ApplicationCommandType, type UserContextMenuCommandInteraction } from 'discord.js';
 import { singleton } from 'tsyringe';
 import { getLocalizedProp, type CommandBody, type Command } from '#struct/Command';
 import { openThread } from '#util/handleThreadManagement';
@@ -13,9 +12,7 @@ export default class implements Command<ApplicationCommandType.User> {
 		dm_permission: false,
 	};
 
-	public constructor(private readonly prisma: PrismaClient, private readonly client: Client) {}
-
-	public async handle(interaction: UserContextMenuCommandInteraction<'cached'>) {
+	public handle(interaction: UserContextMenuCommandInteraction<'cached'>) {
 		return openThread(interaction);
 	}
 }

--- a/packages/bot/src/commands/context-menus/open.ts
+++ b/packages/bot/src/commands/context-menus/open.ts
@@ -1,18 +1,8 @@
-import { PrismaClient } from '@prisma/client';
-import {
-	ApplicationCommandType,
-	Client,
-	Colors,
-	EmbedBuilder,
-	TextChannel,
-	time,
-	TimestampStyles,
-	UserContextMenuCommandInteraction,
-} from 'discord.js';
-import i18next from 'i18next';
+import type { PrismaClient } from '@prisma/client';
+import { ApplicationCommandType, type Client, type UserContextMenuCommandInteraction } from 'discord.js';
 import { singleton } from 'tsyringe';
 import { getLocalizedProp, type CommandBody, type Command } from '#struct/Command';
-import { getSortedMemberRolesString } from '#util/getSortedMemberRoles';
+import { handleThreadManagement } from '#util/handleThreadManagement';
 
 @singleton()
 export default class implements Command<ApplicationCommandType.User> {
@@ -26,83 +16,6 @@ export default class implements Command<ApplicationCommandType.User> {
 	public constructor(private readonly prisma: PrismaClient, private readonly client: Client) {}
 
 	public async handle(interaction: UserContextMenuCommandInteraction<'cached'>) {
-		const settings = await this.prisma.guildSettings.findFirst({ where: { guildId: interaction.guild.id } });
-		if (!settings?.modmailChannelId || !interaction.guild.channels.cache.has(settings.modmailChannelId)) {
-			return interaction.reply(i18next.t('common.errors.thread_creation', { lng: interaction.locale }));
-		}
-
-		const modmail = interaction.guild.channels.cache.get(settings.modmailChannelId) as TextChannel;
-		const existingThread = await this.prisma.thread.findFirst({
-			where: { guildId: interaction.guild.id, userId: interaction.targetUser.id, closedById: null },
-		});
-
-		if (existingThread) {
-			return interaction.reply(i18next.t('common.errors.thread_exists', { lng: interaction.locale }));
-		}
-
-		const member = await interaction.guild.members.fetch(interaction.targetUser).catch(() => null);
-		if (!member) {
-			return interaction.reply(i18next.t('common.errors.no_member', { lng: interaction.locale }));
-		}
-		const pastModmails = await this.prisma.thread.findMany({
-			where: { guildId: interaction.guild.id, userId: member.id },
-		});
-
-		await interaction.deferReply();
-
-		const embed = new EmbedBuilder()
-			.setFooter({ text: `${member.user.tag} (${member.user.id})`, iconURL: member.user.displayAvatarURL() })
-			.setColor(Colors.NotQuiteBlack)
-			.setFields(
-				{
-					name: i18next.t('thread.start.embed.fields.account_created'),
-					value: time(member.user.createdAt, TimestampStyles.LongDate),
-					inline: true,
-				},
-				{
-					name: i18next.t('thread.start.embed.fields.joined_server'),
-					value: time(member.joinedAt!, TimestampStyles.LongDate),
-					inline: true,
-				},
-				{
-					name: i18next.t('thread.start.embed.fields.past_modmails'),
-					value: pastModmails.length.toString(),
-					inline: true,
-				},
-				{
-					name: i18next.t('thread.start.embed.fields.opened_by'),
-					value: interaction.user.toString(),
-					inline: true,
-				},
-				{
-					name: i18next.t('thread.start.embed.fields.roles'),
-					value: getSortedMemberRolesString(member),
-					inline: true,
-				},
-			);
-
-		if (member.nickname) {
-			embed.setAuthor({ name: member.nickname, iconURL: member.displayAvatarURL() });
-		}
-
-		const startMessage = await modmail.send({
-			content: member.toString(),
-			embeds: [embed],
-		});
-
-		const threadChannel = await startMessage.startThread({
-			name: `${member.user.username}-${member.user.discriminator}`,
-		});
-
-		await this.prisma.thread.create({
-			data: {
-				guildId: interaction.guild.id,
-				channelId: threadChannel.id,
-				userId: member.id,
-				createdById: interaction.user.id,
-			},
-		});
-
-		return interaction.editReply(i18next.t('common.success.opened_thread', { lng: interaction.locale }));
+		return handleThreadManagement(interaction);
 	}
 }

--- a/packages/bot/src/commands/context-menus/open.ts
+++ b/packages/bot/src/commands/context-menus/open.ts
@@ -2,7 +2,7 @@ import type { PrismaClient } from '@prisma/client';
 import { ApplicationCommandType, type Client, type UserContextMenuCommandInteraction } from 'discord.js';
 import { singleton } from 'tsyringe';
 import { getLocalizedProp, type CommandBody, type Command } from '#struct/Command';
-import { handleThreadManagement } from '#util/handleThreadManagement';
+import { openThread } from '#util/handleThreadManagement';
 
 @singleton()
 export default class implements Command<ApplicationCommandType.User> {
@@ -16,6 +16,6 @@ export default class implements Command<ApplicationCommandType.User> {
 	public constructor(private readonly prisma: PrismaClient, private readonly client: Client) {}
 
 	public async handle(interaction: UserContextMenuCommandInteraction<'cached'>) {
-		return handleThreadManagement(interaction);
+		return openThread(interaction);
 	}
 }

--- a/packages/bot/src/commands/edit.ts
+++ b/packages/bot/src/commands/edit.ts
@@ -7,7 +7,7 @@ import {
 } from 'discord.js';
 import { singleton } from 'tsyringe';
 import { getLocalizedProp, type CommandBody, type Command } from '#struct/Command';
-import { handleStaffThreadMessage } from '#util/handleStaffThreadMessage';
+import { handleStaffThreadMessage, HandleStaffThreadMessageAction } from '#util/handleStaffThreadMessage';
 
 @singleton()
 export default class implements Command<ApplicationCommandType.ChatInput> {
@@ -46,6 +46,6 @@ export default class implements Command<ApplicationCommandType.ChatInput> {
 	public constructor(private readonly prisma: PrismaClient, private readonly client: Client) {}
 
 	public async handle(interaction: ChatInputCommandInteraction<'cached'>) {
-		return handleStaffThreadMessage(interaction, 'edit');
+		return handleStaffThreadMessage(interaction, HandleStaffThreadMessageAction.Edit);
 	}
 }

--- a/packages/bot/src/commands/edit.ts
+++ b/packages/bot/src/commands/edit.ts
@@ -7,7 +7,7 @@ import {
 } from 'discord.js';
 import { singleton } from 'tsyringe';
 import { getLocalizedProp, type CommandBody, type Command } from '#struct/Command';
-import { handleThreadManagement } from '#util/handleThreadManagement';
+import { handleStaffThreadMessage } from '#util/handleStaffThreadMessage';
 
 @singleton()
 export default class implements Command<ApplicationCommandType.ChatInput> {
@@ -46,6 +46,6 @@ export default class implements Command<ApplicationCommandType.ChatInput> {
 	public constructor(private readonly prisma: PrismaClient, private readonly client: Client) {}
 
 	public async handle(interaction: ChatInputCommandInteraction<'cached'>) {
-		return handleThreadManagement(interaction, 'edit');
+		return handleStaffThreadMessage(interaction, 'edit');
 	}
 }

--- a/packages/bot/src/commands/edit.ts
+++ b/packages/bot/src/commands/edit.ts
@@ -3,13 +3,11 @@ import {
 	ApplicationCommandOptionType,
 	ApplicationCommandType,
 	Client,
-	ThreadChannel,
 	type ChatInputCommandInteraction,
 } from 'discord.js';
-import i18next from 'i18next';
 import { singleton } from 'tsyringe';
 import { getLocalizedProp, type CommandBody, type Command } from '#struct/Command';
-import { sendStaffThreadMessage } from '#util/sendStaffThreadMessage';
+import { handleThreadManagement } from '#util/handleThreadManagement';
 
 @singleton()
 export default class implements Command<ApplicationCommandType.ChatInput> {
@@ -48,60 +46,6 @@ export default class implements Command<ApplicationCommandType.ChatInput> {
 	public constructor(private readonly prisma: PrismaClient, private readonly client: Client) {}
 
 	public async handle(interaction: ChatInputCommandInteraction<'cached'>) {
-		const thread = await this.prisma.thread.findFirst({
-			where: { channelId: interaction.channelId, closedById: null },
-		});
-		if (!thread) {
-			return interaction.reply(i18next.t('common.errors.no_thread'));
-		}
-
-		const id = interaction.options.getInteger('id', true);
-		const threadMessage = await this.prisma.threadMessage.findFirst({ where: { thread, localThreadMessageId: id } });
-		if (!threadMessage) {
-			return interaction.reply(
-				i18next.t('common.errors.resource_not_found', { resource: 'message', lng: interaction.locale }),
-			);
-		}
-
-		if (threadMessage.staffId !== interaction.user.id) {
-			return interaction.reply(i18next.t('common.errors.not_own_message', { lng: interaction.locale }));
-		}
-
-		const content = interaction.options.getString('content', true);
-		const attachment = interaction.options.getAttachment('attachment');
-		const clearAttachment = interaction.options.getBoolean('clear-attachment');
-
-		if (attachment && clearAttachment) {
-			return interaction.reply(
-				i18next.t('common.errors.arg_conflict', {
-					first: 'attachment',
-					second: 'clear-attachment',
-					lng: interaction.locale,
-				}),
-			);
-		}
-
-		const member = await interaction.guild.members.fetch(thread.userId).catch(() => null);
-		if (!member) {
-			return interaction.reply(i18next.t('common.errors.no_member', { lng: interaction.locale }));
-		}
-
-		const settings = await this.prisma.guildSettings.findFirst({ where: { guildId: interaction.guild.id } });
-		const guildMessage = await (interaction.channel as ThreadChannel).messages.fetch(threadMessage.guildMessageId);
-		const userChannel = await member.createDM();
-		const userMessage = await userChannel.messages.fetch(threadMessage.userMessageId);
-
-		await sendStaffThreadMessage({
-			content: content,
-			attachment: clearAttachment ? null : attachment,
-			staff: interaction.member,
-			member,
-			channel: interaction.channel as ThreadChannel,
-			threadId: thread.threadId,
-			simpleMode: settings?.simpleMode ?? false,
-			anon: threadMessage.anon,
-			interaction,
-			existing: { guild: guildMessage, user: userMessage, replyId: threadMessage.localThreadMessageId },
-		});
+		return handleThreadManagement(interaction, 'edit');
 	}
 }

--- a/packages/bot/src/commands/edit.ts
+++ b/packages/bot/src/commands/edit.ts
@@ -1,10 +1,4 @@
-import { PrismaClient } from '@prisma/client';
-import {
-	ApplicationCommandOptionType,
-	ApplicationCommandType,
-	Client,
-	type ChatInputCommandInteraction,
-} from 'discord.js';
+import { ApplicationCommandOptionType, ApplicationCommandType, type ChatInputCommandInteraction } from 'discord.js';
 import { singleton } from 'tsyringe';
 import { getLocalizedProp, type CommandBody, type Command } from '#struct/Command';
 import { handleStaffThreadMessage, HandleStaffThreadMessageAction } from '#util/handleStaffThreadMessage';
@@ -42,8 +36,6 @@ export default class implements Command<ApplicationCommandType.ChatInput> {
 			},
 		],
 	};
-
-	public constructor(private readonly prisma: PrismaClient, private readonly client: Client) {}
 
 	public async handle(interaction: ChatInputCommandInteraction<'cached'>) {
 		return handleStaffThreadMessage(interaction, HandleStaffThreadMessageAction.Edit);

--- a/packages/bot/src/commands/open.ts
+++ b/packages/bot/src/commands/open.ts
@@ -1,19 +1,13 @@
-import { PrismaClient } from '@prisma/client';
+import type { PrismaClient } from '@prisma/client';
 import {
 	ApplicationCommandOptionType,
 	ApplicationCommandType,
-	Client,
-	Colors,
-	EmbedBuilder,
-	TextChannel,
-	time,
-	TimestampStyles,
+	type Client,
 	type ChatInputCommandInteraction,
 } from 'discord.js';
-import i18next from 'i18next';
 import { singleton } from 'tsyringe';
 import { getLocalizedProp, type CommandBody, type Command } from '#struct/Command';
-import { getSortedMemberRolesString } from '#util/getSortedMemberRoles';
+import { handleThreadManagement } from '#util/handleThreadManagement';
 
 @singleton()
 export default class implements Command<ApplicationCommandType.ChatInput> {
@@ -36,84 +30,6 @@ export default class implements Command<ApplicationCommandType.ChatInput> {
 	public constructor(private readonly prisma: PrismaClient, private readonly client: Client) {}
 
 	public async handle(interaction: ChatInputCommandInteraction<'cached'>) {
-		const settings = await this.prisma.guildSettings.findFirst({ where: { guildId: interaction.guild.id } });
-		if (!settings?.modmailChannelId || !interaction.guild.channels.cache.has(settings.modmailChannelId)) {
-			return interaction.reply(i18next.t('common.errors.thread_creation', { lng: interaction.locale }));
-		}
-
-		const modmail = interaction.guild.channels.cache.get(settings.modmailChannelId) as TextChannel;
-		const user = interaction.options.getUser('user', true);
-		const existingThread = await this.prisma.thread.findFirst({
-			where: { guildId: interaction.guild.id, userId: user.id, closedById: null },
-		});
-
-		if (existingThread) {
-			return interaction.reply(i18next.t('common.errors.thread_exists', { lng: interaction.locale }));
-		}
-
-		const member = await interaction.guild.members.fetch(user).catch(() => null);
-		if (!member) {
-			return interaction.reply(i18next.t('common.errors.no_member', { lng: interaction.locale }));
-		}
-		const pastModmails = await this.prisma.thread.findMany({
-			where: { guildId: interaction.guild.id, userId: member.id },
-		});
-
-		await interaction.deferReply();
-
-		const embed = new EmbedBuilder()
-			.setFooter({ text: `${member.user.tag} (${member.user.id})`, iconURL: member.user.displayAvatarURL() })
-			.setColor(Colors.NotQuiteBlack)
-			.setFields(
-				{
-					name: i18next.t('thread.start.embed.fields.account_created'),
-					value: time(member.user.createdAt, TimestampStyles.LongDate),
-					inline: true,
-				},
-				{
-					name: i18next.t('thread.start.embed.fields.joined_server'),
-					value: time(member.joinedAt!, TimestampStyles.LongDate),
-					inline: true,
-				},
-				{
-					name: i18next.t('thread.start.embed.fields.past_modmails'),
-					value: pastModmails.length.toString(),
-					inline: true,
-				},
-				{
-					name: i18next.t('thread.start.embed.fields.opened_by'),
-					value: interaction.user.toString(),
-					inline: true,
-				},
-				{
-					name: i18next.t('thread.start.embed.fields.roles'),
-					value: getSortedMemberRolesString(member),
-					inline: true,
-				},
-			);
-
-		if (member.nickname) {
-			embed.setAuthor({ name: member.nickname, iconURL: member.displayAvatarURL() });
-		}
-
-		const startMessage = await modmail.send({
-			content: member.toString(),
-			embeds: [embed],
-		});
-
-		const threadChannel = await startMessage.startThread({
-			name: `${member.user.username}-${member.user.discriminator}`,
-		});
-
-		await this.prisma.thread.create({
-			data: {
-				guildId: interaction.guild.id,
-				channelId: threadChannel.id,
-				userId: member.id,
-				createdById: interaction.user.id,
-			},
-		});
-
-		return interaction.editReply(i18next.t('common.success.opened_thread', { lng: interaction.locale }));
+		return handleThreadManagement(interaction);
 	}
 }

--- a/packages/bot/src/commands/open.ts
+++ b/packages/bot/src/commands/open.ts
@@ -1,10 +1,4 @@
-import type { PrismaClient } from '@prisma/client';
-import {
-	ApplicationCommandOptionType,
-	ApplicationCommandType,
-	type Client,
-	type ChatInputCommandInteraction,
-} from 'discord.js';
+import { ApplicationCommandOptionType, ApplicationCommandType, type ChatInputCommandInteraction } from 'discord.js';
 import { singleton } from 'tsyringe';
 import { getLocalizedProp, type CommandBody, type Command } from '#struct/Command';
 import { openThread } from '#util/handleThreadManagement';
@@ -27,9 +21,7 @@ export default class implements Command<ApplicationCommandType.ChatInput> {
 		],
 	};
 
-	public constructor(private readonly prisma: PrismaClient, private readonly client: Client) {}
-
-	public async handle(interaction: ChatInputCommandInteraction<'cached'>) {
+	public handle(interaction: ChatInputCommandInteraction<'cached'>) {
 		return openThread(interaction);
 	}
 }

--- a/packages/bot/src/commands/open.ts
+++ b/packages/bot/src/commands/open.ts
@@ -7,7 +7,7 @@ import {
 } from 'discord.js';
 import { singleton } from 'tsyringe';
 import { getLocalizedProp, type CommandBody, type Command } from '#struct/Command';
-import { handleThreadManagement } from '#util/handleThreadManagement';
+import { openThread } from '#util/handleThreadManagement';
 
 @singleton()
 export default class implements Command<ApplicationCommandType.ChatInput> {
@@ -30,6 +30,6 @@ export default class implements Command<ApplicationCommandType.ChatInput> {
 	public constructor(private readonly prisma: PrismaClient, private readonly client: Client) {}
 
 	public async handle(interaction: ChatInputCommandInteraction<'cached'>) {
-		return handleThreadManagement(interaction);
+		return openThread(interaction);
 	}
 }

--- a/packages/bot/src/commands/reply.ts
+++ b/packages/bot/src/commands/reply.ts
@@ -8,7 +8,7 @@ import {
 } from 'discord.js';
 import { singleton } from 'tsyringe';
 import { getLocalizedProp, type CommandBody, type Command } from '#struct/Command';
-import { handleThreadManagement } from '#util/handleThreadManagement';
+import { handleStaffThreadMessage } from '#util/handleStaffThreadMessage';
 
 @singleton()
 export default class implements Command<ApplicationCommandType.ChatInput> {
@@ -55,6 +55,6 @@ export default class implements Command<ApplicationCommandType.ChatInput> {
 	}
 
 	public async handle(interaction: ChatInputCommandInteraction<'cached'>) {
-		return handleThreadManagement(interaction, 'reply');
+		return handleStaffThreadMessage(interaction, 'reply');
 	}
 }

--- a/packages/bot/src/commands/reply.ts
+++ b/packages/bot/src/commands/reply.ts
@@ -2,15 +2,13 @@ import { PrismaClient } from '@prisma/client';
 import {
 	ApplicationCommandOptionType,
 	ApplicationCommandType,
-	ThreadChannel,
 	type ApplicationCommandOptionChoiceData,
 	type AutocompleteInteraction,
 	type ChatInputCommandInteraction,
 } from 'discord.js';
-import i18next from 'i18next';
 import { singleton } from 'tsyringe';
 import { getLocalizedProp, type CommandBody, type Command } from '#struct/Command';
-import { sendStaffThreadMessage } from '#util/sendStaffThreadMessage';
+import { handleThreadManagement } from '#util/handleThreadManagement';
 
 @singleton()
 export default class implements Command<ApplicationCommandType.ChatInput> {
@@ -57,34 +55,6 @@ export default class implements Command<ApplicationCommandType.ChatInput> {
 	}
 
 	public async handle(interaction: ChatInputCommandInteraction<'cached'>) {
-		const thread = await this.prisma.thread.findFirst({
-			where: { channelId: interaction.channelId, closedById: null },
-		});
-		if (!thread) {
-			return interaction.reply(i18next.t('common.errors.no_thread'));
-		}
-
-		const content = interaction.options.getString('content', true);
-		const attachment = interaction.options.getAttachment('attachment');
-		const anon = interaction.options.getBoolean('anon');
-
-		const member = await interaction.guild.members.fetch(thread.userId).catch(() => null);
-		if (!member) {
-			return i18next.t('common.errors.no_member', { lng: interaction.locale });
-		}
-
-		const settings = await this.prisma.guildSettings.findFirst({ where: { guildId: interaction.guild.id } });
-
-		await sendStaffThreadMessage({
-			content,
-			attachment,
-			staff: interaction.member,
-			member,
-			channel: interaction.channel as ThreadChannel,
-			threadId: thread.threadId,
-			simpleMode: settings?.simpleMode ?? false,
-			anon: anon ?? false,
-			interaction,
-		});
+		return handleThreadManagement(interaction, 'reply');
 	}
 }

--- a/packages/bot/src/commands/reply.ts
+++ b/packages/bot/src/commands/reply.ts
@@ -8,7 +8,7 @@ import {
 } from 'discord.js';
 import { singleton } from 'tsyringe';
 import { getLocalizedProp, type CommandBody, type Command } from '#struct/Command';
-import { handleStaffThreadMessage } from '#util/handleStaffThreadMessage';
+import { handleStaffThreadMessage, HandleStaffThreadMessageAction } from '#util/handleStaffThreadMessage';
 
 @singleton()
 export default class implements Command<ApplicationCommandType.ChatInput> {
@@ -54,7 +54,7 @@ export default class implements Command<ApplicationCommandType.ChatInput> {
 			.slice(0, 5);
 	}
 
-	public async handle(interaction: ChatInputCommandInteraction<'cached'>) {
-		return handleStaffThreadMessage(interaction, 'reply');
+	public handle(interaction: ChatInputCommandInteraction<'cached'>) {
+		return handleStaffThreadMessage(interaction, HandleStaffThreadMessageAction.Reply);
 	}
 }

--- a/packages/bot/src/util/handleStaffThreadMessage.ts
+++ b/packages/bot/src/util/handleStaffThreadMessage.ts
@@ -1,0 +1,88 @@
+import { PrismaClient } from '@prisma/client';
+import type { ChatInputCommandInteraction, ThreadChannel } from 'discord.js';
+import i18next from 'i18next';
+import { container } from 'tsyringe';
+import { sendStaffThreadMessage, type SendStaffThreadMessageOptions } from './sendStaffThreadMessage';
+
+/**
+ *
+ * @param interaction A received interaction from the edit and reply commands.
+ * @param action Which command was used to call this function.
+ */
+export async function handleStaffThreadMessage(
+	interaction: ChatInputCommandInteraction<'cached'>,
+	action: 'reply' | 'edit',
+) {
+	const prisma = container.resolve(PrismaClient);
+
+	const thread = await prisma.thread.findFirst({
+		where: { channelId: interaction.channelId, closedById: null },
+	});
+	if (!thread) {
+		return interaction.reply(i18next.t('common.errors.no_thread'));
+	}
+
+	const options: Partial<SendStaffThreadMessageOptions> = {
+		content: interaction.options.getString('content', true),
+		staff: interaction.member,
+		channel: interaction.channel as ThreadChannel,
+		interaction,
+		threadId: thread.threadId,
+	};
+
+	const attachment = interaction.options.getAttachment('attachment');
+
+	const member = await interaction.guild.members.fetch(thread.userId).catch(() => null);
+	if (!member) {
+		return interaction.reply(i18next.t('common.errors.no_member', { lng: interaction.locale }));
+	}
+	options.member = member;
+
+	if (action === 'reply') {
+		options.anon = interaction.options.getBoolean('anon') ?? false;
+		options.attachment = attachment;
+	} else {
+		const id = interaction.options.getInteger('id', true);
+		const threadMessage = await prisma.threadMessage.findFirst({ where: { thread, localThreadMessageId: id } });
+		if (!threadMessage) {
+			return interaction.reply(
+				i18next.t('common.errors.resource_not_found', { resource: 'message', lng: interaction.locale }),
+			);
+		}
+
+		if (threadMessage.staffId !== interaction.user.id) {
+			return interaction.reply(i18next.t('common.errors.not_own_message', { lng: interaction.locale }));
+		}
+
+		const clearAttachment = interaction.options.getBoolean('clear-attachment');
+
+		if (attachment && clearAttachment) {
+			return interaction.reply(
+				i18next.t('common.errors.arg_conflict', {
+					first: 'attachment',
+					second: 'clear-attachment',
+					lng: interaction.locale,
+				}),
+			);
+		}
+
+		const guildMessage = await interaction.channel!.messages.fetch(threadMessage.guildMessageId);
+		const userChannel = await member.createDM();
+		const userMessage = await userChannel.messages.fetch(threadMessage.userMessageId);
+
+		Object.assign<typeof options, Partial<typeof options>>(options, {
+			attachment: clearAttachment ? null : attachment,
+			anon: threadMessage.anon,
+			existing: {
+				guild: guildMessage,
+				user: userMessage,
+				replyId: threadMessage.localThreadMessageId,
+			},
+		});
+	}
+
+	const settings = await prisma.guildSettings.findFirst({ where: { guildId: interaction.guild.id } });
+	options.simpleMode = settings?.simpleMode ?? false;
+
+	return sendStaffThreadMessage(options as SendStaffThreadMessageOptions);
+}

--- a/packages/bot/src/util/handleThreadManagement.ts
+++ b/packages/bot/src/util/handleThreadManagement.ts
@@ -2,10 +2,17 @@ import { PrismaClient } from '@prisma/client';
 import type { ChatInputCommandInteraction, ThreadChannel } from 'discord.js';
 import i18next from 'i18next';
 import { container } from 'tsyringe';
-import { sendStaffThreadMessage } from './sendStaffThreadMessage';
+import { sendStaffThreadMessage, type SendStaffThreadMessageOptions } from './sendStaffThreadMessage';
 
-// TODO: Change this up later, currently is a copy-paste of edit command's handle function
-export async function handleThreadManagement(interaction: ChatInputCommandInteraction<'cached'>) {
+/**
+ *
+ * @param interaction A received interaction from the edit and reply commands.
+ * @param action Which command was used to call this function.
+ */
+export async function handleThreadManagement(
+	interaction: ChatInputCommandInteraction<'cached'>,
+	action: 'reply' | 'edit',
+) {
 	const prisma = container.resolve(PrismaClient);
 
 	const thread = await prisma.thread.findFirst({
@@ -15,52 +22,67 @@ export async function handleThreadManagement(interaction: ChatInputCommandIntera
 		return interaction.reply(i18next.t('common.errors.no_thread'));
 	}
 
-	const id = interaction.options.getInteger('id', true);
-	const threadMessage = await prisma.threadMessage.findFirst({ where: { thread, localThreadMessageId: id } });
-	if (!threadMessage) {
-		return interaction.reply(
-			i18next.t('common.errors.resource_not_found', { resource: 'message', lng: interaction.locale }),
-		);
-	}
+	const options: Partial<SendStaffThreadMessageOptions> = {
+		content: interaction.options.getString('content', true),
+		staff: interaction.member,
+		channel: interaction.channel as ThreadChannel,
+		interaction,
+		threadId: thread.threadId,
+	};
 
-	if (threadMessage.staffId !== interaction.user.id) {
-		return interaction.reply(i18next.t('common.errors.not_own_message', { lng: interaction.locale }));
-	}
-
-	const content = interaction.options.getString('content', true);
 	const attachment = interaction.options.getAttachment('attachment');
-	const clearAttachment = interaction.options.getBoolean('clear-attachment');
-
-	if (attachment && clearAttachment) {
-		return interaction.reply(
-			i18next.t('common.errors.arg_conflict', {
-				first: 'attachment',
-				second: 'clear-attachment',
-				lng: interaction.locale,
-			}),
-		);
-	}
 
 	const member = await interaction.guild.members.fetch(thread.userId).catch(() => null);
 	if (!member) {
 		return interaction.reply(i18next.t('common.errors.no_member', { lng: interaction.locale }));
 	}
+	options.member = member;
+
+	if (action === 'reply') {
+		options.anon = interaction.options.getBoolean('anon') ?? false;
+		options.attachment = attachment;
+	} else {
+		const id = interaction.options.getInteger('id', true);
+		const threadMessage = await prisma.threadMessage.findFirst({ where: { thread, localThreadMessageId: id } });
+		if (!threadMessage) {
+			return interaction.reply(
+				i18next.t('common.errors.resource_not_found', { resource: 'message', lng: interaction.locale }),
+			);
+		}
+
+		if (threadMessage.staffId !== interaction.user.id) {
+			return interaction.reply(i18next.t('common.errors.not_own_message', { lng: interaction.locale }));
+		}
+
+		const clearAttachment = interaction.options.getBoolean('clear-attachment');
+
+		if (attachment && clearAttachment) {
+			return interaction.reply(
+				i18next.t('common.errors.arg_conflict', {
+					first: 'attachment',
+					second: 'clear-attachment',
+					lng: interaction.locale,
+				}),
+			);
+		}
+
+		const guildMessage = await interaction.channel!.messages.fetch(threadMessage.guildMessageId);
+		const userChannel = await member.createDM();
+		const userMessage = await userChannel.messages.fetch(threadMessage.userMessageId);
+
+		Object.assign<typeof options, Partial<typeof options>>(options, {
+			attachment: clearAttachment ? null : attachment,
+			anon: threadMessage.anon,
+			existing: {
+				guild: guildMessage,
+				user: userMessage,
+				replyId: threadMessage.localThreadMessageId,
+			},
+		});
+	}
 
 	const settings = await prisma.guildSettings.findFirst({ where: { guildId: interaction.guild.id } });
-	const guildMessage = await (interaction.channel as ThreadChannel).messages.fetch(threadMessage.guildMessageId);
-	const userChannel = await member.createDM();
-	const userMessage = await userChannel.messages.fetch(threadMessage.userMessageId);
+	options.simpleMode = settings?.simpleMode ?? false;
 
-	await sendStaffThreadMessage({
-		content: content,
-		attachment: clearAttachment ? null : attachment,
-		staff: interaction.member,
-		member,
-		channel: interaction.channel as ThreadChannel,
-		threadId: thread.threadId,
-		simpleMode: settings?.simpleMode ?? false,
-		anon: threadMessage.anon,
-		interaction,
-		existing: { guild: guildMessage, user: userMessage, replyId: threadMessage.localThreadMessageId },
-	});
+	return sendStaffThreadMessage(options as SendStaffThreadMessageOptions);
 }

--- a/packages/bot/src/util/handleThreadManagement.ts
+++ b/packages/bot/src/util/handleThreadManagement.ts
@@ -1,0 +1,66 @@
+import { PrismaClient } from '@prisma/client';
+import type { ChatInputCommandInteraction, ThreadChannel } from 'discord.js';
+import i18next from 'i18next';
+import { container } from 'tsyringe';
+import { sendStaffThreadMessage } from './sendStaffThreadMessage';
+
+// TODO: Change this up later, currently is a copy-paste of edit command's handle function
+export async function handleThreadManagement(interaction: ChatInputCommandInteraction<'cached'>) {
+	const prisma = container.resolve(PrismaClient);
+
+	const thread = await prisma.thread.findFirst({
+		where: { channelId: interaction.channelId, closedById: null },
+	});
+	if (!thread) {
+		return interaction.reply(i18next.t('common.errors.no_thread'));
+	}
+
+	const id = interaction.options.getInteger('id', true);
+	const threadMessage = await prisma.threadMessage.findFirst({ where: { thread, localThreadMessageId: id } });
+	if (!threadMessage) {
+		return interaction.reply(
+			i18next.t('common.errors.resource_not_found', { resource: 'message', lng: interaction.locale }),
+		);
+	}
+
+	if (threadMessage.staffId !== interaction.user.id) {
+		return interaction.reply(i18next.t('common.errors.not_own_message', { lng: interaction.locale }));
+	}
+
+	const content = interaction.options.getString('content', true);
+	const attachment = interaction.options.getAttachment('attachment');
+	const clearAttachment = interaction.options.getBoolean('clear-attachment');
+
+	if (attachment && clearAttachment) {
+		return interaction.reply(
+			i18next.t('common.errors.arg_conflict', {
+				first: 'attachment',
+				second: 'clear-attachment',
+				lng: interaction.locale,
+			}),
+		);
+	}
+
+	const member = await interaction.guild.members.fetch(thread.userId).catch(() => null);
+	if (!member) {
+		return interaction.reply(i18next.t('common.errors.no_member', { lng: interaction.locale }));
+	}
+
+	const settings = await prisma.guildSettings.findFirst({ where: { guildId: interaction.guild.id } });
+	const guildMessage = await (interaction.channel as ThreadChannel).messages.fetch(threadMessage.guildMessageId);
+	const userChannel = await member.createDM();
+	const userMessage = await userChannel.messages.fetch(threadMessage.userMessageId);
+
+	await sendStaffThreadMessage({
+		content: content,
+		attachment: clearAttachment ? null : attachment,
+		staff: interaction.member,
+		member,
+		channel: interaction.channel as ThreadChannel,
+		threadId: thread.threadId,
+		simpleMode: settings?.simpleMode ?? false,
+		anon: threadMessage.anon,
+		interaction,
+		existing: { guild: guildMessage, user: userMessage, replyId: threadMessage.localThreadMessageId },
+	});
+}

--- a/packages/bot/src/util/sendStaffThreadMessage.ts
+++ b/packages/bot/src/util/sendStaffThreadMessage.ts
@@ -152,5 +152,5 @@ export async function sendStaffThreadMessage({
 		options.embeds = [embed];
 	}
 
-	await guildMessage.edit(options as MessageEditOptions);
+	return guildMessage.edit(options as MessageEditOptions);
 }


### PR DESCRIPTION
implements a couple of utilities to reduce code dupe.

**NOTE: the current names of the utilities may need to be changed and more thread-related commands and/or contexts may need to be reduced still.**

- `handleStaffThreadMessage`: this puts all of the code needed for the `reply` and `edit` commands into a single utility.

- `handleThreadManagement`: this directs both the command and context counterpart of `open` within it.
