### PR TITLE
fix: show the correct user who opened the thread

### DIFF
--- a/packages/bot/src/util/handleThreadManagement.ts
+++ b/packages/bot/src/util/handleThreadManagement.ts
@@ -105,7 +105,7 @@ export async function openThread(
 			},
 			{
 				name: i18next.t('thread.start.embed.fields.opened_by'),
-				value: user.toString(),
+				value: isMessage ? input.author.toString() : input.user.toString(),
 				inline: true,
 			},
 			{


### PR DESCRIPTION
corrects the field in the opened thread embed that states who opened the thread.