### PR TITLE
feat(bot): add proper perms checks

### DIFF
--- a/packages/bot/src/commands/alert.ts
+++ b/packages/bot/src/commands/alert.ts
@@ -1,4 +1,5 @@
 import { PrismaClient } from '@prisma/client';
+import type { PermissionResolvable } from 'discord.js';
 import { ApplicationCommandType, type ChatInputCommandInteraction } from 'discord.js';
 import i18next from 'i18next';
 import { singleton } from 'tsyringe';
@@ -14,6 +15,8 @@ export default class implements Command<ApplicationCommandType.ChatInput> {
 		default_member_permissions: '0',
 		dm_permission: false,
 	};
+
+	public requiredClientPermissions: PermissionResolvable = 'SendMessages';
 
 	public constructor(private readonly prisma: PrismaClient) {}
 

--- a/packages/bot/src/commands/block.ts
+++ b/packages/bot/src/commands/block.ts
@@ -1,5 +1,6 @@
 import { ms } from '@naval-base/ms';
 import { PrismaClient } from '@prisma/client';
+import type { PermissionResolvable } from 'discord.js';
 import {
 	ApplicationCommandOptionType,
 	ApplicationCommandType,
@@ -28,6 +29,8 @@ export default class implements Command<ApplicationCommandType.ChatInput> {
 			},
 		],
 	};
+
+	public requiredClientPermissions: PermissionResolvable = 'SendMessagesInThreads';
 
 	public constructor(private readonly prisma: PrismaClient, private readonly client: Client) {}
 

--- a/packages/bot/src/commands/close.ts
+++ b/packages/bot/src/commands/close.ts
@@ -1,6 +1,6 @@
 import { ms } from '@naval-base/ms';
 import { PrismaClient } from '@prisma/client';
-import type { ThreadChannel } from 'discord.js';
+import type { PermissionResolvable, ThreadChannel } from 'discord.js';
 import { ApplicationCommandOptionType, ApplicationCommandType, type ChatInputCommandInteraction } from 'discord.js';
 import i18next from 'i18next';
 import { singleton } from 'tsyringe';
@@ -35,6 +35,8 @@ export default class implements Command<ApplicationCommandType.ChatInput> {
 			},
 		],
 	};
+
+	public requiredClientPermissions: PermissionResolvable = ['SendMessagesInThreads', 'ManageThreads', 'EmbedLinks'];
 
 	public constructor(private readonly prisma: PrismaClient) {}
 

--- a/packages/bot/src/commands/config.ts
+++ b/packages/bot/src/commands/config.ts
@@ -1,7 +1,7 @@
 import type { GuildSettings } from '@prisma/client';
 import { PrismaClient } from '@prisma/client';
 import { stripIndents } from 'common-tags';
-import type { TextChannel } from 'discord.js';
+import type { PermissionResolvable, TextChannel } from 'discord.js';
 import {
 	ApplicationCommandOptionType,
 	ApplicationCommandType,
@@ -49,6 +49,8 @@ export default class implements Command<ApplicationCommandType.ChatInput> {
 			},
 		],
 	};
+
+	public requiredClientPermissions: PermissionResolvable = 'SendMessages';
 
 	public constructor(private readonly prisma: PrismaClient, private readonly client: Client) {}
 

--- a/packages/bot/src/commands/context-menus/createSnippet.ts
+++ b/packages/bot/src/commands/context-menus/createSnippet.ts
@@ -1,4 +1,4 @@
-import type { MessageContextMenuCommandInteraction } from 'discord.js';
+import type { MessageContextMenuCommandInteraction, PermissionResolvable } from 'discord.js';
 import { ApplicationCommandType } from 'discord.js';
 import { singleton } from 'tsyringe';
 import promptSnippetAdd from '../../modals/snippets/add';
@@ -13,6 +13,8 @@ export default class implements Command<ApplicationCommandType.Message> {
 		default_member_permissions: '0',
 		dm_permission: false,
 	};
+
+	public requiredClientPermissions: PermissionResolvable = 'SendMessages';
 
 	public async handle(interaction: MessageContextMenuCommandInteraction<'cached'>) {
 		const targetMessageContent = interaction.targetMessage.content;

--- a/packages/bot/src/commands/context-menus/expose.ts
+++ b/packages/bot/src/commands/context-menus/expose.ts
@@ -1,5 +1,5 @@
 import { PrismaClient } from '@prisma/client';
-import type { MessageContextMenuCommandInteraction } from 'discord.js';
+import type { MessageContextMenuCommandInteraction, PermissionResolvable } from 'discord.js';
 import { ApplicationCommandType, Client } from 'discord.js';
 import i18next from 'i18next';
 import { singleton } from 'tsyringe';
@@ -13,6 +13,8 @@ export default class implements Command<ApplicationCommandType.Message> {
 		default_member_permissions: '0',
 		dm_permission: false,
 	};
+
+	public requiredClientPermissions: PermissionResolvable = 'SendMessages';
 
 	public constructor(private readonly prisma: PrismaClient, private readonly client: Client) {}
 

--- a/packages/bot/src/commands/context-menus/open.ts
+++ b/packages/bot/src/commands/context-menus/open.ts
@@ -1,3 +1,4 @@
+import type { PermissionResolvable } from 'discord.js';
 import { ApplicationCommandType, type UserContextMenuCommandInteraction } from 'discord.js';
 import { singleton } from 'tsyringe';
 import { getLocalizedProp, type CommandBody, type Command } from '#struct/Command';
@@ -11,6 +12,14 @@ export default class implements Command<ApplicationCommandType.User> {
 		default_member_permissions: '0',
 		dm_permission: false,
 	};
+
+	public readonly requiredClientPermissions: PermissionResolvable = [
+		'CreatePublicThreads',
+		'CreatePrivateThreads',
+		'SendMessages',
+		'SendMessagesInThreads',
+		'EmbedLinks',
+	];
 
 	public async handle(interaction: UserContextMenuCommandInteraction<'cached'>) {
 		return openThread(interaction);

--- a/packages/bot/src/commands/context-menus/reply-anon.ts
+++ b/packages/bot/src/commands/context-menus/reply-anon.ts
@@ -1,4 +1,4 @@
-import type { MessageContextMenuCommandInteraction } from 'discord.js';
+import type { MessageContextMenuCommandInteraction, PermissionResolvable } from 'discord.js';
 import { ApplicationCommandType } from 'discord.js';
 import { singleton } from 'tsyringe';
 import ReplyContextMenu from './reply';
@@ -12,6 +12,8 @@ export default class implements Command<ApplicationCommandType.Message> {
 		default_member_permissions: '0',
 		dm_permission: false,
 	};
+
+	public requiredClientPermissions: PermissionResolvable = ['SendMessagesInThreads', 'EmbedLinks'];
 
 	public constructor(private readonly replyContextMenu: ReplyContextMenu) {}
 

--- a/packages/bot/src/commands/context-menus/reply.ts
+++ b/packages/bot/src/commands/context-menus/reply.ts
@@ -1,5 +1,5 @@
 import { PrismaClient } from '@prisma/client';
-import type { MessageContextMenuCommandInteraction, ThreadChannel } from 'discord.js';
+import type { MessageContextMenuCommandInteraction, PermissionResolvable, ThreadChannel } from 'discord.js';
 import { ApplicationCommandType } from 'discord.js';
 import i18next from 'i18next';
 import { singleton } from 'tsyringe';
@@ -14,6 +14,8 @@ export default class implements Command<ApplicationCommandType.Message> {
 		default_member_permissions: '0',
 		dm_permission: false,
 	};
+
+	public requiredClientPermissions: PermissionResolvable = ['SendMessagesInThreads', 'EmbedLinks'];
 
 	public constructor(private readonly prisma: PrismaClient) {}
 

--- a/packages/bot/src/commands/delete.ts
+++ b/packages/bot/src/commands/delete.ts
@@ -1,5 +1,5 @@
 import { PrismaClient } from '@prisma/client';
-import type { ThreadChannel } from 'discord.js';
+import type { PermissionResolvable, ThreadChannel } from 'discord.js';
 import {
 	ApplicationCommandOptionType,
 	ApplicationCommandType,
@@ -27,6 +27,8 @@ export default class implements Command<ApplicationCommandType.ChatInput> {
 			},
 		],
 	};
+
+	public requiredClientPermissions: PermissionResolvable = ['ManageThreads'];
 
 	public constructor(private readonly prisma: PrismaClient, private readonly client: Client) {}
 

--- a/packages/bot/src/commands/edit.ts
+++ b/packages/bot/src/commands/edit.ts
@@ -1,3 +1,4 @@
+import type { PermissionResolvable } from 'discord.js';
 import { ApplicationCommandOptionType, ApplicationCommandType, type ChatInputCommandInteraction } from 'discord.js';
 import { singleton } from 'tsyringe';
 import { getLocalizedProp, type CommandBody, type Command } from '#struct/Command';
@@ -36,6 +37,8 @@ export default class implements Command<ApplicationCommandType.ChatInput> {
 			},
 		],
 	};
+
+	public requiredClientPermissions: PermissionResolvable = 'SendMessagesInThreads';
 
 	public async handle(interaction: ChatInputCommandInteraction<'cached'>) {
 		return handleStaffThreadMessage(interaction, HandleStaffThreadMessageAction.Edit);

--- a/packages/bot/src/commands/logs.ts
+++ b/packages/bot/src/commands/logs.ts
@@ -1,6 +1,6 @@
 import type { Thread } from '@prisma/client';
 import { PrismaClient } from '@prisma/client';
-import type { ButtonBuilder } from 'discord.js';
+import type { ButtonBuilder, PermissionResolvable } from 'discord.js';
 import {
 	ActionRowBuilder,
 	ApplicationCommandOptionType,
@@ -36,6 +36,8 @@ export default class implements Command<ApplicationCommandType.ChatInput> {
 			},
 		],
 	};
+
+	public requiredClientPermissions: PermissionResolvable = ["SendMessages", "EmbedLinks"];
 
 	public constructor(private readonly prisma: PrismaClient, private readonly client: Client) {}
 

--- a/packages/bot/src/commands/logs.ts
+++ b/packages/bot/src/commands/logs.ts
@@ -37,7 +37,7 @@ export default class implements Command<ApplicationCommandType.ChatInput> {
 		],
 	};
 
-	public requiredClientPermissions: PermissionResolvable = ["SendMessages", "EmbedLinks"];
+	public requiredClientPermissions: PermissionResolvable = ['SendMessages', 'EmbedLinks'];
 
 	public constructor(private readonly prisma: PrismaClient, private readonly client: Client) {}
 

--- a/packages/bot/src/commands/open.ts
+++ b/packages/bot/src/commands/open.ts
@@ -1,3 +1,4 @@
+import type { PermissionResolvable } from 'discord.js';
 import { ApplicationCommandOptionType, ApplicationCommandType, type ChatInputCommandInteraction } from 'discord.js';
 import { singleton } from 'tsyringe';
 import { getLocalizedProp, type CommandBody, type Command } from '#struct/Command';
@@ -20,6 +21,14 @@ export default class implements Command<ApplicationCommandType.ChatInput> {
 			},
 		],
 	};
+
+	public readonly requiredClientPermissions: PermissionResolvable = [
+		'CreatePublicThreads',
+		'CreatePrivateThreads',
+		'SendMessages',
+		'SendMessagesInThreads',
+		'EmbedLinks',
+	];
 
 	public async handle(interaction: ChatInputCommandInteraction<'cached'>) {
 		return openThread(interaction);

--- a/packages/bot/src/commands/reply.ts
+++ b/packages/bot/src/commands/reply.ts
@@ -1,4 +1,5 @@
 import { PrismaClient } from '@prisma/client';
+import type { PermissionResolvable } from 'discord.js';
 import {
 	ApplicationCommandOptionType,
 	ApplicationCommandType,
@@ -37,6 +38,8 @@ export default class implements Command<ApplicationCommandType.ChatInput> {
 			},
 		],
 	};
+
+	public requiredClientPermissions: PermissionResolvable = ['SendMessagesInThreads', 'EmbedLinks'];
 
 	public constructor(private readonly prisma: PrismaClient) {}
 

--- a/packages/bot/src/commands/snippets/add.ts
+++ b/packages/bot/src/commands/snippets/add.ts
@@ -1,4 +1,8 @@
-import type { APIApplicationCommandSubcommandOption, ChatInputCommandInteraction } from 'discord.js';
+import type {
+	APIApplicationCommandSubcommandOption,
+	ChatInputCommandInteraction,
+	PermissionResolvable,
+} from 'discord.js';
 import { singleton } from 'tsyringe';
 import promptSnippetAdd from '../../modals/snippets/add';
 import { getLocalizedProp, type Subcommand } from '#struct/Command';
@@ -10,6 +14,8 @@ export default class implements Subcommand {
 		...getLocalizedProp('description', 'commands.snippets.add.description'),
 		options: [],
 	};
+
+	public requiredClientPermissions: PermissionResolvable = 'SendMessages';
 
 	public async handle(interaction: ChatInputCommandInteraction<'cached'>) {
 		return promptSnippetAdd(interaction);

--- a/packages/bot/src/commands/snippets/edit.ts
+++ b/packages/bot/src/commands/snippets/edit.ts
@@ -1,4 +1,5 @@
 import { PrismaClient } from '@prisma/client';
+import type { PermissionResolvable } from 'discord.js';
 import {
 	type APIApplicationCommandSubcommandOption,
 	ApplicationCommandOptionType,
@@ -29,6 +30,8 @@ export default class implements Subcommand {
 			},
 		],
 	};
+
+	public requiredClientPermissions: PermissionResolvable = 'SendMessages';
 
 	public constructor(private readonly prisma: PrismaClient) {}
 

--- a/packages/bot/src/commands/snippets/list.ts
+++ b/packages/bot/src/commands/snippets/list.ts
@@ -1,5 +1,5 @@
 import { PrismaClient, type Snippet } from '@prisma/client';
-import type { ButtonBuilder } from 'discord.js';
+import type { ButtonBuilder, PermissionResolvable } from 'discord.js';
 import {
 	type APIApplicationCommandSubcommandOption,
 	type ChatInputCommandInteraction,
@@ -20,6 +20,8 @@ export default class implements Subcommand {
 		...getLocalizedProp('name', 'commands.snippets.list.name'),
 		...getLocalizedProp('description', 'commands.snippets.list.description'),
 	};
+
+	public requiredClientPermissions: PermissionResolvable = ['SendMessages', 'EmbedLinks'];
 
 	public constructor(private readonly prisma: PrismaClient) {}
 

--- a/packages/bot/src/commands/snippets/remove.ts
+++ b/packages/bot/src/commands/snippets/remove.ts
@@ -1,4 +1,5 @@
 import { PrismaClient } from '@prisma/client';
+import type { PermissionResolvable } from 'discord.js';
 import {
 	type APIApplicationCommandSubcommandOption,
 	ApplicationCommandOptionType,
@@ -23,6 +24,8 @@ export default class implements Subcommand {
 			},
 		],
 	};
+
+	public requiredClientPermissions: PermissionResolvable = 'SendMessages';
 
 	public constructor(private readonly prisma: PrismaClient) {}
 

--- a/packages/bot/src/commands/snippets/show.ts
+++ b/packages/bot/src/commands/snippets/show.ts
@@ -1,5 +1,5 @@
 import { PrismaClient, type Snippet, type SnippetUpdates } from '@prisma/client';
-import type { APIEmbedField } from 'discord.js';
+import type { APIEmbedField, PermissionResolvable } from 'discord.js';
 import {
 	type APIApplicationCommandSubcommandOption,
 	ApplicationCommandOptionType,
@@ -37,6 +37,8 @@ export default class implements Subcommand {
 			},
 		],
 	};
+
+	public requiredClientPermissions: PermissionResolvable = ['SendMessages', 'EmbedLinks'];
 
 	public constructor(private readonly prisma: PrismaClient, private readonly client: Client) {}
 

--- a/packages/bot/src/commands/unblock.ts
+++ b/packages/bot/src/commands/unblock.ts
@@ -1,4 +1,5 @@
 import { Prisma, PrismaClient } from '@prisma/client';
+import type { PermissionResolvable } from 'discord.js';
 import {
 	ApplicationCommandOptionType,
 	ApplicationCommandType,
@@ -26,6 +27,8 @@ export default class implements Command<ApplicationCommandType.ChatInput> {
 			},
 		],
 	};
+
+	public requiredClientPermissions: PermissionResolvable = 'SendMessagesInThreads';
 
 	public constructor(private readonly prisma: PrismaClient, private readonly client: Client) {}
 

--- a/packages/bot/src/struct/Command.ts
+++ b/packages/bot/src/struct/Command.ts
@@ -1,3 +1,4 @@
+import type { PermissionResolvable } from 'discord.js';
 import {
 	type ApplicationCommandOptionChoiceData,
 	type ApplicationCommandType,
@@ -27,12 +28,14 @@ export type Command<Type extends ApplicationCommandType = ApplicationCommandType
 	handle(interaction: InteractionTypeMapping[Type]): Awaitable<unknown>;
 	handleAutocomplete?(interaction: AutocompleteInteraction<any>): Awaitable<ApplicationCommandOptionChoiceData[]>;
 	readonly interactionOptions: CommandBody<Type>;
+	readonly requiredClientPermissions?: PermissionResolvable;
 };
 
 export type CommandWithSubcommands = {
 	readonly containsSubcommands: true;
 	handleAutocomplete?(interaction: AutocompleteInteraction<any>): Awaitable<ApplicationCommandOptionChoiceData[]>;
 	readonly interactionOptions: Omit<CommandBody<ApplicationCommandType.ChatInput>, 'options' | 'type'>;
+	readonly requiredClientPermissions?: PermissionResolvable;
 };
 
 export type Subcommand = Omit<

--- a/packages/bot/src/struct/CommandHandler.ts
+++ b/packages/bot/src/struct/CommandHandler.ts
@@ -125,14 +125,14 @@ export class CommandHandler {
 		try {
 			if (!command.containsSubcommands) {
 				if (!command.interactionOptions.dm_permission && command.requiredClientPermissions) {
-					const missingRequiredBotPermissions = this.checkForBotMissingPermissions(
+					const missingRequiredClientPermissions = this.checkForMissingClientPermissions(
 						interaction.appPermissions!,
 						command.requiredClientPermissions,
 					);
-					if (missingRequiredBotPermissions.length) {
+					if (missingRequiredClientPermissions.length) {
 						return await interaction.reply({
 							content: `The bot is missing the following permissions to run this command: ${inlineCode(
-								missingRequiredBotPermissions.join(', '),
+								missingRequiredClientPermissions.join(', '),
 							)}`,
 							ephemeral: true,
 						});
@@ -158,14 +158,14 @@ export class CommandHandler {
 			}
 
 			if (!command.interactionOptions.dm_permission && subcommand.requiredClientPermissions) {
-				const missingRequiredBotPermissions = this.checkForBotMissingPermissions(
+				const missingRequiredClientPermissions = this.checkForMissingClientPermissions(
 					interaction.appPermissions!,
 					subcommand.requiredClientPermissions,
 				);
-				if (missingRequiredBotPermissions.length) {
+				if (missingRequiredClientPermissions.length) {
 					return await interaction.reply({
 						content: `The bot is missing the following permissions to run this command: ${inlineCode(
-							missingRequiredBotPermissions.join(', '),
+							missingRequiredClientPermissions.join(', '),
 						)}`,
 						ephemeral: true,
 					});
@@ -202,10 +202,13 @@ export class CommandHandler {
 		return Promise.all([this.registerCommands(), this.registerComponents()]);
 	}
 
-	public checkForBotMissingPermissions(botPermissions: PermissionsBitField, clientPermissions: PermissionResolvable) {
-		const requiredClientPermissions = new PermissionsBitField(clientPermissions);
-		if (requiredClientPermissions.bitfield) {
-			const missingClientPermissions = botPermissions.missing(requiredClientPermissions);
+	public checkForMissingClientPermissions(
+		clientPermissions: PermissionsBitField,
+		requiredClientPermissions: PermissionResolvable,
+	) {
+		const requiredClientPermissionsBitField = new PermissionsBitField(clientPermissions);
+		if (requiredClientPermissionsBitField.bitfield) {
+			const missingClientPermissions = clientPermissions.missing(requiredClientPermissions);
 			if (missingClientPermissions.length) {
 				return missingClientPermissions;
 			}


### PR DESCRIPTION
Adds a `requiredClientPermissions` field to the `Command` struct, and a `checkForMissingClientPermissions` method on the command handler to check if there are missing client permissions that the specific command needs to run (that got specified on the added command struct field)
Closes #30 